### PR TITLE
Fixed compilation with GCC.

### DIFF
--- a/CMakeRC.cmake
+++ b/CMakeRC.cmake
@@ -182,14 +182,14 @@ public:
     created_subdirectory add_subdir(std::string name) & {
         _dirs.emplace_back();
         auto& back = _dirs.back();
-        auto& fod = _index.emplace(name, back).first->second;
+        auto& fod = _index.emplace(name, file_or_directory{back}).first->second;
         return created_subdirectory{back, fod};
     }
 
     file_or_directory* add_file(std::string name, const char* begin, const char* end) & {
         assert(_index.find(name) == _index.end());
         _files.emplace_back(begin, end);
-        return &_index.emplace(name, _files.back()).first->second;
+        return &_index.emplace(name, file_or_directory{_files.back()}).first->second;
     }
 
     const file_or_directory* get(const std::string& path) const {


### PR DESCRIPTION
Since file_or_directory's constructors are explicit then need to use
explicit type conversion when emplacing to std::map.