### PR TITLE
Added trailing zero to array.

### DIFF
--- a/CMakeRC.cmake
+++ b/CMakeRC.cmake
@@ -21,7 +21,7 @@ if(_CMRC_GENERATE_MODE)
         string(REGEX REPLACE "${cleanup_re}" "${cleanup_sub}" chars "${chars}")
     endif()
     string(CONFIGURE [[
-        namespace { const char file_array[] = { @chars@ }; }
+        namespace { const char file_array[] = { @chars@ 0 }; }
         namespace cmrc { namespace @NAMESPACE@ { namespace res_chars {
         extern const char* const @SYMBOL@_begin = file_array;
         extern const char* const @SYMBOL@_end = file_array + @n_bytes@;


### PR DESCRIPTION
Without much overhead, this commit allows to embed files with textual
data and then pass a pointer to this data to any function that expects
null-terminated string. When reading file with text, previously it was
mandatory to make a copy of a content and append a trailing null character.