### PR TITLE
Use version range for CMake policies

### DIFF
--- a/CMakeRC.cmake
+++ b/CMakeRC.cmake
@@ -34,7 +34,7 @@ endif()
 
 set(_version 2.0.0)
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.3...3.16)
 include(CMakeParseArguments)
 
 if(COMMAND cmrc_add_resource_library)


### PR DESCRIPTION
From CMake 3.12 onwards this sets policies to whatever version is current up to 3.16. This prevents noisy policy warnings.