### PR TITLE
Increased performance significantly using incbin library

### DIFF
--- a/CMakeRC.cmake
+++ b/CMakeRC.cmake
@@ -1,36 +1,55 @@
 # This block is executed when generating an intermediate resource file, not when
 # running in CMake configure mode
 if(_CMRC_GENERATE_MODE)
-    # Read in the digits
-    file(READ "${INPUT_FILE}" bytes HEX)
-    # Format each pair into a character literal. Heuristics seem to favor doing
-    # the conversion in groups of five for fastest conversion
-    string(REGEX REPLACE "(..)(..)(..)(..)(..)" "'\\\\x\\1','\\\\x\\2','\\\\x\\3','\\\\x\\4','\\\\x\\5'," chars "${bytes}")
-    # Since we did this in groups, we have some leftovers to clean up
-    string(LENGTH "${bytes}" n_bytes2)
-    math(EXPR n_bytes "${n_bytes2} / 2")
-    math(EXPR remainder "${n_bytes} % 5") # <-- '5' is the grouping count from above
-    set(cleanup_re "$")
-    set(cleanup_sub )
-    while(remainder)
-        set(cleanup_re "(..)${cleanup_re}")
-        set(cleanup_sub "'\\\\x\\${remainder}',${cleanup_sub}")
-        math(EXPR remainder "${remainder} - 1")
-    endwhile()
-    if(NOT cleanup_re STREQUAL "$")
-        string(REGEX REPLACE "${cleanup_re}" "${cleanup_sub}" chars "${chars}")
-    endif()
-    string(CONFIGURE [[
+    if (INCBIN_ENABLED)
+
+        string(CONFIGURE [[
+        #include <incbin/incbin.h>
+        namespace cmrc { namespace @NAMESPACE@ { namespace res_chars {
+        INCBIN(@SYMBOL@, "@INPUT_FILE@");
+        extern const char* const @SYMBOL@_begin = (const char*) g@SYMBOL@Data;
+        extern const char* const @SYMBOL@_end = (const char*) (g@SYMBOL@Data + g@SYMBOL@Size);
+        }}}
+        ]] code)
+
+    else()
+        
+        # Read in the digits
+        file(READ "${INPUT_FILE}" bytes HEX)
+        # Format each pair into a character literal. Heuristics seem to favor doing
+        # the conversion in groups of five for fastest conversion
+        string(REGEX REPLACE "(..)(..)(..)(..)(..)" "'\\\\x\\1','\\\\x\\2','\\\\x\\3','\\\\x\\4','\\\\x\\5'," chars "${bytes}")
+        # Since we did this in groups, we have some leftovers to clean up
+        string(LENGTH "${bytes}" n_bytes2)
+        math(EXPR n_bytes "${n_bytes2} / 2")
+        math(EXPR remainder "${n_bytes} % 5") # <-- '5' is the grouping count from above
+        set(cleanup_re "$")
+        set(cleanup_sub )
+        while(remainder)
+            set(cleanup_re "(..)${cleanup_re}")
+            set(cleanup_sub "'\\\\x\\${remainder}',${cleanup_sub}")
+            math(EXPR remainder "${remainder} - 1")
+        endwhile()
+        if(NOT cleanup_re STREQUAL "$")
+            string(REGEX REPLACE "${cleanup_re}" "${cleanup_sub}" chars "${chars}")
+        endif()
+
+        string(CONFIGURE [[
         namespace { const char file_array[] = { @chars@ 0 }; }
         namespace cmrc { namespace @NAMESPACE@ { namespace res_chars {
         extern const char* const @SYMBOL@_begin = file_array;
         extern const char* const @SYMBOL@_end = file_array + @n_bytes@;
         }}}
-    ]] code)
+        ]] code)
+        
+    endif()
+
     file(WRITE "${OUTPUT_FILE}" "${code}")
     # Exit from the script. Nothing else needs to be processed
     return()
 endif()
+
+
 
 set(_version 2.0.0)
 
@@ -387,11 +406,469 @@ endif()
 file(GENERATE OUTPUT "${cmrc_hpp}" CONTENT "${hpp_content}" CONDITION ${_generate})
 
 add_library(cmrc-base INTERFACE)
-target_include_directories(cmrc-base INTERFACE "${CMRC_INCLUDE_DIR}")
+
+# Add interface include for users of library
+target_include_directories(cmrc-base INTERFACE "$<BUILD_INTERFACE:${CMRC_INCLUDE_DIR}>")
+
 # Signal a basic C++11 feature to require C++11.
 target_compile_features(cmrc-base INTERFACE cxx_nullptr)
 set_property(TARGET cmrc-base PROPERTY INTERFACE_CXX_EXTENSIONS OFF)
 add_library(cmrc::base ALIAS cmrc-base)
+
+
+
+### Incbin project addition, this enables much quicker compile times on supported compilers
+# https://github.com/graphitemaster/incbin
+# Incbin project
+# Commit: 8cefe46d5380bf5ae4b4d87832d811f6692aae44
+
+# Create an option to use it (default on, with try_compile checks to make sure it works)
+option(CMRC_COMPATIBILITY_MODE "If enabled intermediate character array is generated (Supports all compilers)" OFF)
+
+set(incbin_h_content [==[
+/**
+ * @file incbin.h
+ * @author Dale Weiler
+ * @brief Utility for including binary files
+ *
+ * Facilities for including binary files into the current translation unit and
+ * making use from them externally in other translation units.
+ */
+#ifndef INCBIN_HDR
+#define INCBIN_HDR
+#include <limits.h>
+#if   defined(__AVX512BW__) || \
+      defined(__AVX512CD__) || \
+      defined(__AVX512DQ__) || \
+      defined(__AVX512ER__) || \
+      defined(__AVX512PF__) || \
+      defined(__AVX512VL__) || \
+      defined(__AVX512F__)
+# define INCBIN_ALIGNMENT_INDEX 6
+#elif defined(__AVX__)      || \
+      defined(__AVX2__)
+# define INCBIN_ALIGNMENT_INDEX 5
+#elif defined(__SSE__)      || \
+      defined(__SSE2__)     || \
+      defined(__SSE3__)     || \
+      defined(__SSSE3__)    || \
+      defined(__SSE4_1__)   || \
+      defined(__SSE4_2__)   || \
+      defined(__neon__)
+# define INCBIN_ALIGNMENT_INDEX 4
+#elif ULONG_MAX != 0xffffffffu
+# define INCBIN_ALIGNMENT_INDEX 3
+# else
+# define INCBIN_ALIGNMENT_INDEX 2
+#endif
+
+/* Lookup table of (1 << n) where `n' is `INCBIN_ALIGNMENT_INDEX' */
+#define INCBIN_ALIGN_SHIFT_0 1
+#define INCBIN_ALIGN_SHIFT_1 2
+#define INCBIN_ALIGN_SHIFT_2 4
+#define INCBIN_ALIGN_SHIFT_3 8
+#define INCBIN_ALIGN_SHIFT_4 16
+#define INCBIN_ALIGN_SHIFT_5 32
+#define INCBIN_ALIGN_SHIFT_6 64
+
+/* Actual alignment value */
+#define INCBIN_ALIGNMENT \
+    INCBIN_CONCATENATE( \
+        INCBIN_CONCATENATE(INCBIN_ALIGN_SHIFT, _), \
+        INCBIN_ALIGNMENT_INDEX)
+
+/* Stringize */
+#define INCBIN_STR(X) \
+    #X
+#define INCBIN_STRINGIZE(X) \
+    INCBIN_STR(X)
+/* Concatenate */
+#define INCBIN_CAT(X, Y) \
+    X ## Y
+#define INCBIN_CONCATENATE(X, Y) \
+    INCBIN_CAT(X, Y)
+/* Deferred macro expansion */
+#define INCBIN_EVAL(X) \
+    X
+#define INCBIN_INVOKE(N, ...) \
+    INCBIN_EVAL(N(__VA_ARGS__))
+
+/* Green Hills uses a different directive for including binary data */
+#if defined(__ghs__)
+#  if (__ghs_asm == 2)
+#    define INCBIN_MACRO ".file"
+/* Or consider the ".myrawdata" entry in the ld file */
+#  else
+#    define INCBIN_MACRO "\tINCBIN"
+#  endif
+#else
+#  define INCBIN_MACRO ".incbin"
+#endif
+
+#ifndef _MSC_VER
+#  define INCBIN_ALIGN \
+    __attribute__((aligned(INCBIN_ALIGNMENT)))
+#else
+#  define INCBIN_ALIGN __declspec(align(INCBIN_ALIGNMENT))
+#endif
+
+#if defined(__arm__) || /* GNU C and RealView */ \
+    defined(__arm) || /* Diab */ \
+    defined(_ARM) /* ImageCraft */
+#  define INCBIN_ARM
+#endif
+
+#ifdef __GNUC__
+/* Utilize .balign where supported */
+#  define INCBIN_ALIGN_HOST ".balign " INCBIN_STRINGIZE(INCBIN_ALIGNMENT) "\n"
+#  define INCBIN_ALIGN_BYTE ".balign 1\n"
+#elif defined(INCBIN_ARM)
+/*
+ * On arm assemblers, the alignment value is calculated as (1 << n) where `n' is
+ * the shift count. This is the value passed to `.align'
+ */
+#  define INCBIN_ALIGN_HOST ".align " INCBIN_STRINGIZE(INCBIN_ALIGNMENT_INDEX) "\n"
+#  define INCBIN_ALIGN_BYTE ".align 0\n"
+#else
+/* We assume other inline assembler's treat `.align' as `.balign' */
+#  define INCBIN_ALIGN_HOST ".align " INCBIN_STRINGIZE(INCBIN_ALIGNMENT) "\n"
+#  define INCBIN_ALIGN_BYTE ".align 1\n"
+#endif
+
+/* INCBIN_CONST is used by incbin.c generated files */
+#if defined(__cplusplus)
+#  define INCBIN_EXTERNAL extern "C"
+#  define INCBIN_CONST    extern const
+#else
+#  define INCBIN_EXTERNAL extern
+#  define INCBIN_CONST    const
+#endif
+
+/**
+ * @brief Optionally override the linker section into which data is emitted.
+ *
+ * @warning If you use this facility, you'll have to deal with platform-specific linker output
+ * section naming on your own
+ *
+ * Overriding the default linker output section, e.g for esp8266/Arduino:
+ * @code
+ * #define INCBIN_OUTPUT_SECTION ".irom.text"
+ * #include "incbin.h"
+ * INCBIN(Foo, "foo.txt");
+ * // Data is emitted into program memory that never gets copied to RAM
+ * @endcode
+ */
+#if !defined(INCBIN_OUTPUT_SECTION)
+#  if defined(__APPLE__)
+#    define INCBIN_OUTPUT_SECTION         ".const_data"
+#  else
+#    define INCBIN_OUTPUT_SECTION         ".rodata"
+#  endif
+#endif
+
+#if defined(__APPLE__)
+/* The directives are different for Apple branded compilers */
+#  define INCBIN_SECTION         INCBIN_OUTPUT_SECTION "\n"
+#  define INCBIN_GLOBAL(NAME)    ".globl " INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
+#  define INCBIN_INT             ".long "
+#  define INCBIN_MANGLE          "_"
+#  define INCBIN_BYTE            ".byte "
+#  define INCBIN_TYPE(...)
+#else
+#  define INCBIN_SECTION         ".section " INCBIN_OUTPUT_SECTION "\n"
+#  define INCBIN_GLOBAL(NAME)    ".global " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME "\n"
+#  if defined(__ghs__)
+#    define INCBIN_INT           ".word "
+#  else
+#    define INCBIN_INT           ".int "
+#  endif
+#  if defined(__USER_LABEL_PREFIX__)
+#    define INCBIN_MANGLE        INCBIN_STRINGIZE(__USER_LABEL_PREFIX__)
+#  else
+#    define INCBIN_MANGLE        ""
+#  endif
+#  if defined(INCBIN_ARM)
+/* On arm assemblers, `@' is used as a line comment token */
+#    define INCBIN_TYPE(NAME)    ".type " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME ", %object\n"
+#  elif defined(__MINGW32__) || defined(__MINGW64__)
+/* Mingw doesn't support this directive either */
+#    define INCBIN_TYPE(NAME)
+#  else
+/* It's safe to use `@' on other architectures */
+#    define INCBIN_TYPE(NAME)    ".type " INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME ", @object\n"
+#  endif
+#  define INCBIN_BYTE            ".byte "
+#endif
+
+/* List of style types used for symbol names */
+#define INCBIN_STYLE_CAMEL 0
+#define INCBIN_STYLE_SNAKE 1
+
+/**
+ * @brief Specify the prefix to use for symbol names.
+ *
+ * By default this is `g', producing symbols of the form:
+ * @code
+ * #include "incbin.h"
+ * INCBIN(Foo, "foo.txt");
+ *
+ * // Now you have the following symbols:
+ * // const unsigned char gFooData[];
+ * // const unsigned char *const gFooEnd;
+ * // const unsigned int gFooSize;
+ * @endcode
+ *
+ * If however you specify a prefix before including: e.g:
+ * @code
+ * #define INCBIN_PREFIX incbin
+ * #include "incbin.h"
+ * INCBIN(Foo, "foo.txt");
+ *
+ * // Now you have the following symbols instead:
+ * // const unsigned char incbinFooData[];
+ * // const unsigned char *const incbinFooEnd;
+ * // const unsigned int incbinFooSize;
+ * @endcode
+ */
+#if !defined(INCBIN_PREFIX)
+#  define INCBIN_PREFIX g
+#endif
+
+/**
+ * @brief Specify the style used for symbol names.
+ *
+ * Possible options are
+ * - INCBIN_STYLE_CAMEL "CamelCase"
+ * - INCBIN_STYLE_SNAKE "snake_case"
+ *
+ * Default option is *INCBIN_STYLE_CAMEL* producing symbols of the form:
+ * @code
+ * #include "incbin.h"
+ * INCBIN(Foo, "foo.txt");
+ *
+ * // Now you have the following symbols:
+ * // const unsigned char <prefix>FooData[];
+ * // const unsigned char *const <prefix>FooEnd;
+ * // const unsigned int <prefix>FooSize;
+ * @endcode
+ *
+ * If however you specify a style before including: e.g:
+ * @code
+ * #define INCBIN_STYLE INCBIN_STYLE_SNAKE
+ * #include "incbin.h"
+ * INCBIN(foo, "foo.txt");
+ *
+ * // Now you have the following symbols:
+ * // const unsigned char <prefix>foo_data[];
+ * // const unsigned char *const <prefix>foo_end;
+ * // const unsigned int <prefix>foo_size;
+ * @endcode
+ */
+#if !defined(INCBIN_STYLE)
+#  define INCBIN_STYLE INCBIN_STYLE_CAMEL
+#endif
+
+/* Style lookup tables */
+#define INCBIN_STYLE_0_DATA Data
+#define INCBIN_STYLE_0_END End
+#define INCBIN_STYLE_0_SIZE Size
+#define INCBIN_STYLE_1_DATA _data
+#define INCBIN_STYLE_1_END _end
+#define INCBIN_STYLE_1_SIZE _size
+
+/* Style lookup: returning identifier */
+#define INCBIN_STYLE_IDENT(TYPE) \
+    INCBIN_CONCATENATE( \
+        INCBIN_STYLE_, \
+        INCBIN_CONCATENATE( \
+            INCBIN_EVAL(INCBIN_STYLE), \
+            INCBIN_CONCATENATE(_, TYPE)))
+
+/* Style lookup: returning string literal */
+#define INCBIN_STYLE_STRING(TYPE) \
+    INCBIN_STRINGIZE( \
+        INCBIN_STYLE_IDENT(TYPE)) \
+
+/* Generate the global labels by indirectly invoking the macro with our style
+ * type and concatenating the name against them. */
+#define INCBIN_GLOBAL_LABELS(NAME, TYPE) \
+    INCBIN_INVOKE( \
+        INCBIN_GLOBAL, \
+        INCBIN_CONCATENATE( \
+            NAME, \
+            INCBIN_INVOKE( \
+                INCBIN_STYLE_IDENT, \
+                TYPE))) \
+    INCBIN_INVOKE( \
+        INCBIN_TYPE, \
+        INCBIN_CONCATENATE( \
+            NAME, \
+            INCBIN_INVOKE( \
+                INCBIN_STYLE_IDENT, \
+                TYPE)))
+
+/**
+ * @brief Externally reference binary data included in another translation unit.
+ *
+ * Produces three external symbols that reference the binary data included in
+ * another translation unit.
+ *
+ * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
+ * "Data", as well as "End" and "Size" after. An example is provided below.
+ *
+ * @param NAME The name given for the binary data
+ *
+ * @code
+ * INCBIN_EXTERN(Foo);
+ *
+ * // Now you have the following symbols:
+ * // extern const unsigned char <prefix>FooData[];
+ * // extern const unsigned char *const <prefix>FooEnd;
+ * // extern const unsigned int <prefix>FooSize;
+ * @endcode
+ */
+#define INCBIN_EXTERN(NAME) \
+    INCBIN_EXTERNAL const INCBIN_ALIGN unsigned char \
+        INCBIN_CONCATENATE( \
+            INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+            INCBIN_STYLE_IDENT(DATA))[]; \
+    INCBIN_EXTERNAL const INCBIN_ALIGN unsigned char *const \
+    INCBIN_CONCATENATE( \
+        INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+        INCBIN_STYLE_IDENT(END)); \
+    INCBIN_EXTERNAL const unsigned int \
+        INCBIN_CONCATENATE( \
+            INCBIN_CONCATENATE(INCBIN_PREFIX, NAME), \
+            INCBIN_STYLE_IDENT(SIZE))
+
+/**
+ * @brief Include a binary file into the current translation unit.
+ *
+ * Includes a binary file into the current translation unit, producing three symbols
+ * for objects that encode the data and size respectively.
+ *
+ * The symbol names are a concatenation of `INCBIN_PREFIX' before *NAME*; with
+ * "Data", as well as "End" and "Size" after. An example is provided below.
+ *
+ * @param NAME The name to associate with this binary data (as an identifier.)
+ * @param FILENAME The file to include (as a string literal.)
+ *
+ * @code
+ * INCBIN(Icon, "icon.png");
+ *
+ * // Now you have the following symbols:
+ * // const unsigned char <prefix>IconData[];
+ * // const unsigned char *const <prefix>IconEnd;
+ * // const unsigned int <prefix>IconSize;
+ * @endcode
+ *
+ * @warning This must be used in global scope
+ * @warning The identifiers may be different if INCBIN_STYLE is not default
+ *
+ * To externally reference the data included by this in another translation unit
+ * please @see INCBIN_EXTERN.
+ */
+#ifdef _MSC_VER
+#define INCBIN(NAME, FILENAME) \
+    INCBIN_EXTERN(NAME)
+#else
+#define INCBIN(NAME, FILENAME) \
+    __asm__(INCBIN_SECTION \
+            INCBIN_GLOBAL_LABELS(NAME, DATA) \
+            INCBIN_ALIGN_HOST \
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(DATA) ":\n" \
+            INCBIN_MACRO " \"" FILENAME "\"\n" \
+            INCBIN_GLOBAL_LABELS(NAME, END) \
+            INCBIN_ALIGN_BYTE \
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) ":\n" \
+                INCBIN_BYTE "1\n" \
+            INCBIN_GLOBAL_LABELS(NAME, SIZE) \
+            INCBIN_ALIGN_HOST \
+            INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(SIZE) ":\n" \
+                INCBIN_INT INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(END) " - " \
+                           INCBIN_MANGLE INCBIN_STRINGIZE(INCBIN_PREFIX) #NAME INCBIN_STYLE_STRING(DATA) "\n" \
+            INCBIN_ALIGN_HOST \
+            ".text\n" \
+    ); \
+    INCBIN_EXTERN(NAME)
+
+#endif
+#endif
+]==])
+
+if (CMRC_COMPATIBILITY_MODE)
+    set(HAVE_INCBIN_CAPABILITY FALSE CACHE INTERNAL "")
+else()
+
+    get_filename_component(_inc_gen_dir "${CMAKE_BINARY_DIR}/_cmrc/gen/include" ABSOLUTE)
+    # Lets generate incbin.h file
+    file(MAKE_DIRECTORY "${_inc_gen_dir}/incbin")
+
+
+    # Create in generate stage
+    set(cmrc_incbin_h "${_inc_gen_dir}/incbin/incbin.h" CACHE INTERNAL "")
+    set(_incbin_generate 1)
+    if(EXISTS "${cmrc_incbin_h}")
+        file(READ "${cmrc_incbin_h}" _incbin_current)
+        if(_incbin_current STREQUAL incbin_h_content)
+            set(_incbin_generate 0)
+        endif()
+    endif()
+    file(GENERATE OUTPUT "${cmrc_incbin_h}" CONTENT "${incbin_h_content}" CONDITION ${_incbin_generate})
+
+    # Tests if incbin assembly directive works for current compiler (otherwise fallback to generating character array)
+
+    if(NOT CMRC_INCBIN_TESTS_DONE)
+
+        # Let's generate the test for incbin.h
+        get_filename_component(_tests_gen_dir "${CMAKE_BINARY_DIR}/_cmrc/tests" ABSOLUTE)
+        file(MAKE_DIRECTORY "${_tests_gen_dir}")
+
+        # Create a sample input file
+        set(test_txt_content [==[
+        Hello World!
+        ]==])
+        file(WRITE "${_tests_gen_dir}/test.txt" "${test_txt_content}")
+
+        # Create a test program source
+        string(CONFIGURE [==[
+        #define INCBIN_PREFIX g_
+        #define INCBIN_STYLE INCBIN_STYLE_SNAKE
+        @incbin_h_content@
+        namespace test{
+            INCBIN(test, "@_tests_gen_dir@/test.txt");
+        }
+        int main(){
+            int sum = 0;
+            for(unsigned int i = 0; i<test::g_test_size; i++){
+                sum += test::g_test_data[i];
+            }
+            return sum;
+        }
+        ]==] test_cpp_content @ONLY)
+        file(WRITE "${_tests_gen_dir}/test.cpp" "${test_cpp_content}")
+
+
+        # Now try to compile
+        message(STATUS "Check for working incbin assembly directive")
+        try_compile(HAVE_INCBIN_CAPABILITY "${_tests_gen_dir}" "${_tests_gen_dir}/test.cpp"
+            CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${_inc_gen_dir}"
+        )
+        if(HAVE_INCBIN_CAPABILITY)
+            message(STATUS "Check for working incbin assembly directive - works")
+        else()
+            message(STATUS "Check for working incbin assembly directive - does not work")
+            message(STATUS "CMRC - Compatibility mode, creating intermediate character array files")
+        endif()
+
+        # Remove tests
+        file(REMOVE_RECURSE "${_tests_gen_dir}")
+
+        set(CMRC_INCBIN_TESTS_DONE TRUE CACHE INTERNAL "")
+
+    endif()
+
+endif()
 
 function(cmrc_add_resource_library name)
     set(args ALIAS NAMESPACE)
@@ -469,6 +946,10 @@ function(cmrc_add_resource_library name)
     # with a character array compiled in containing the contents of the
     # corresponding resource file.
     add_library(${name} STATIC ${libcpp})
+    
+    # Add private include to incbin/incbin.h
+    target_include_directories(${name} PRIVATE "${_inc_gen_dir}")
+
     set_property(TARGET ${name} PROPERTY CMRC_LIBDIR "${libdir}")
     set_property(TARGET ${name} PROPERTY CMRC_NAMESPACE "${ARG_NAMESPACE}")
     target_link_libraries(${name} PUBLIC cmrc::base)
@@ -568,7 +1049,7 @@ function(cmrc_add_resources name)
             _cm_encode_fpath(parent_sym "${dirpath}")
         endif()
         # Generate the rule for the intermediate source file
-        _cmrc_generate_intermediate_cpp(${lib_ns} ${sym} "${abs_out}" "${abs_in}")
+        _cmrc_generate_intermediate_cpp(${lib_ns} ${sym} "${abs_out}" "${abs_in}" "${HAVE_INCBIN_CAPABILITY}")
         target_sources(${name} PRIVATE "${abs_out}")
         set_property(TARGET ${name} APPEND PROPERTY CMRC_EXTERN_DECLS
             "// Pointers to ${input}"
@@ -591,7 +1072,7 @@ function(cmrc_add_resources name)
     endforeach()
 endfunction()
 
-function(_cmrc_generate_intermediate_cpp lib_ns symbol outfile infile)
+function(_cmrc_generate_intermediate_cpp lib_ns symbol outfile infile incbin_enabled)
     add_custom_command(
         # This is the file we will generate
         OUTPUT "${outfile}"
@@ -604,6 +1085,7 @@ function(_cmrc_generate_intermediate_cpp lib_ns symbol outfile infile)
                 -DSYMBOL=${symbol}
                 "-DINPUT_FILE=${infile}"
                 "-DOUTPUT_FILE=${outfile}"
+                "-DINCBIN_ENABLED=${incbin_enabled}"
                 -P "${_CMRC_SCRIPT}"
         COMMENT "Generating intermediate file for ${infile}"
     )


### PR DESCRIPTION
# Performance and memory usage improvement
Hi!
Big fan of CMakeRC library. Lately I've been working with it a lot and came up with an idea to use the incbin assembly directive to include binary data without the need to create the large character array in the intermediate source file. 

I've used the following library: https://github.com/graphitemaster/incbin
Which is also license wise compatible to integrate it into this project.
This adds support for many compilers with exception of MSVC (See: https://github.com/graphitemaster/incbin#portability)
Their solution for MSVC is, to generate intermediate character array files for that case - which this library already does by default :)

I've added a try_compile test which tries to use the incbin library and it falls back to "compatibility mode" if it fails to do so successfully.

Please comment on any changes that would be required to improve this feature.

## Performance Increase: 
Running improved library with a compiler which supports incbin assembly directive yields enormous performance boost.

### Running tests
Machine: i7-4700MQ, GCC 8.4.0, Ubuntu 18.04

Compatibility mode enabled (performance without this feature)
```
cmake .. -DCMRC_COMPATIBILITY_MODE=ON
time cmake --build . --parallel
```
Result: **9.675s** **<- Before**

Compatibility off (by default)
```
cmake .. 
time cmake --build . --parallel
```
Result: **3.080s** **<- After**

## Memory usage:
On Raspberry Pi 3, I had issues using this library with ~5MB files, as the device ran out of available memory. With the above feature, it compiled successfully without any issues. 

Running the included tests again with improved library:

```/usr/bin/time -v cmake --build . --parallel```

Memory usage
Before: **540MB**
After: **86MB**

 