### PR TITLE
Fix Visual Stdio build warning C26478

### DIFF
--- a/CMakeRC.cmake
+++ b/CMakeRC.cmake
@@ -299,7 +299,7 @@ public:
         return _fname;
     }
     std::string filename() const && {
-        return std::move(_fname);
+        return _fname;
     }
 
     bool is_file() const {


### PR DESCRIPTION
Fix Visual Stdio build warning `C26478 Don't use std::move on constant variables. (es.56).` which is caused by below codes:
```
    std::string filename() const && {
        return std::move(_fname);
    }
```

