### PR TITLE
Make cmrc "install-friendly"

### DIFF
--- a/CMakeRC.cmake
+++ b/CMakeRC.cmake
@@ -387,7 +387,7 @@ endif()
 file(GENERATE OUTPUT "${cmrc_hpp}" CONTENT "${hpp_content}" CONDITION ${_generate})
 
 add_library(cmrc-base INTERFACE)
-target_include_directories(cmrc-base INTERFACE "${CMRC_INCLUDE_DIR}")
+target_include_directories(cmrc-base INTERFACE $<BUILD_INTERFACE:${CMRC_INCLUDE_DIR}>)
 # Signal a basic C++11 feature to require C++11.
 target_compile_features(cmrc-base INTERFACE cxx_nullptr)
 set_property(TARGET cmrc-base PROPERTY INTERFACE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
Fixes #26 

Set the include dir only for build interface. We don't need to set the install interface, so long as the cmrc headers are not included from public headers.