### PR TITLE
Fix pre-increment and post-increment operators on iterator

### DIFF
--- a/CMakeRC.cmake
+++ b/CMakeRC.cmake
@@ -248,14 +248,14 @@ public:
         }
 
         iterator operator++() noexcept {
-            auto cp = *this;
             ++_base_iter;
-            return cp;
+            return *this;
         }
 
         iterator& operator++(int) noexcept {
+            auto cp = *this;
             ++_base_iter;
-            return *this;
+            return cp;
         }
     };
 

--- a/CMakeRC.cmake
+++ b/CMakeRC.cmake
@@ -247,12 +247,12 @@ public:
             return !(*this == rhs);
         }
 
-        iterator operator++() noexcept {
+        iterator& operator++() noexcept {
             ++_base_iter;
             return *this;
         }
 
-        iterator& operator++(int) noexcept {
+        iterator operator++(int) noexcept {
             auto cp = *this;
             ++_base_iter;
             return cp;


### PR DESCRIPTION
As per https://en.cppreference.com/w/cpp/language/operator_incdec

the `operator++()` is pre-increment and should behave:

> Pre-increment and pre-decrement operators increments or decrements the value of the object and returns a reference to the result.

the `operator++(int)` is post-increment and should behave:

> Post-increment and post-decrement creates a copy of the object, increments or decrements the value of the object and returns the copy from before the increment or decrement. 

The implementations are just switched with this.