### PR TITLE
Fix file conflict in intermediate dir

### DIFF
--- a/CMakeRC.cmake
+++ b/CMakeRC.cmake
@@ -585,7 +585,7 @@ function(cmrc_add_resources name)
         endif()
         get_filename_component(dirpath "${ARG_PREFIX}${relpath}" DIRECTORY)
         _cmrc_register_dirs("${name}" "${dirpath}")
-        get_filename_component(abs_out "${libdir}/intermediate/${relpath}.cpp" ABSOLUTE)
+        get_filename_component(abs_out "${libdir}/intermediate/${ARG_PREFIX}${relpath}.cpp" ABSOLUTE)
         # Generate a symbol name relpath the file's character array
         _cm_encode_fpath(sym "${relpath}")
         # Get the symbol name for the parent directory


### PR DESCRIPTION
Using the `WHENCE` option can lead to conflicting files. The [documentation](https://github.com/vector-of-bool/cmrc#additional-options) says conflicts could be avoided using the `PREFIX` option.
The problem is, the prefix seems not to be used for the generation of the intermediate files, leading to conflicts during configuration.

This PR will add the prefix to the intermediate path, to avoid these conflicts, but I'm not 100% sure if this change will have any unwanted side effects.

Example for reproduction of the problem:
```
cmrc_add_resource_library(resources)
cmrc_add_resources(resources WHENCE "A" PREFIX "FileA/FooBar" A/Test/file.txt)
cmrc_add_resources(resources WHENCE "B" PREFIX "FileB/FooBar" B/Test/file.txt)
```