### PR TITLE
Mention vcpkg port in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ required is the `CMakeRC.cmake` script. You can copy it into your project
 directory (recommended) or install it as a package and get all the features you
 need.
 
+For [vcpkg](https://github.com/microsoft/vcpkg) users there is a `cmakerc` [port](https://github.com/microsoft/vcpkg/tree/master/ports/cmakerc) that can be installed via `vcpkg install cmakerc` or by adding it to `dependencies` section of your `vcpkg.json` file.
+
 ## Usage
 
 1. Once installed, simply import the `CMakeRC.cmake` script. If you placed the


### PR DESCRIPTION
I've added CMakeRC to vcpkg so I think that mentioning this may help vcpkg users a bit

Nothing special happens if you do `vcpkg install cmakerc`. It just allows you to not having the actual cmake file in your repo so it's a little bit cleaner. It's hosted in vcpkg installed dir instead.