### PR TITLE
Add SYSTEM to target_include_directories

### DIFF
--- a/CMakeRC.cmake
+++ b/CMakeRC.cmake
@@ -406,7 +406,7 @@ endif()
 file(GENERATE OUTPUT "${cmrc_hpp}" CONTENT "${hpp_content}" CONDITION ${_generate})
 
 add_library(cmrc-base INTERFACE)
-target_include_directories(cmrc-base INTERFACE $<BUILD_INTERFACE:${CMRC_INCLUDE_DIR}>)
+target_include_directories(cmrc-base SYSTEM INTERFACE $<BUILD_INTERFACE:${CMRC_INCLUDE_DIR}>)
 # Signal a basic C++11 feature to require C++11.
 target_compile_features(cmrc-base INTERFACE cxx_nullptr)
 set_property(TARGET cmrc-base PROPERTY INTERFACE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
Add `SYSTEM` to `target_include_directories` call to prevent warnings from generated code from polluting own code.