### PR TITLE
Increase cmake_min_req to prevent deprecation

### DIFF
--- a/CMakeRC.cmake
+++ b/CMakeRC.cmake
@@ -34,7 +34,7 @@ endif()
 
 set(_version 2.0.0)
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.12)
 include(CMakeParseArguments)
 
 if(COMMAND cmrc_add_resource_library)


### PR DESCRIPTION
Cmake 3.27+ complains about cmake 3.5 or lower, with a deprecation warning. Increasing the min_req does not break anything else and fixes that warning.