### PR TITLE
Add new file access methods to support more use cases conveniently

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Require a decent version of CMake
+cmake_minimum_required(VERSION 3.6)
+
+# Include the CMRC module
+include(../CMakeRC.cmake)
+
+# Define the example project
+project(cmrc_example)
+
+# Add an executable to the project
+add_executable(cmrc_example example.cpp)
+
+# In this case we would like to use get_as_string_view() which requries C++17.
+# If this is not needed the following lines can be skipped.
+target_compile_features(cmrc_example PRIVATE cxx_std_17)
+if(MSVC)
+    # MSVC favors their own backwards compatibilty over standards compliance.
+    # The below option ensures the __cplusplus pre-processing variable in MSVC
+    # is actually standards compliant.
+    target_compile_options(cmrc_example PRIVATE "/Zc:__cplusplus")
+endif()
+
+# Create a "resource library" called "myrclib" which will hold the resources.
+# We also create a CMake ALIAS to the library which can be used when linking.
+# Finally we choose to add a text file as a first resource.
+cmrc_add_resource_library(
+    myrclib
+    NAMESPACE rc
+    ALIAS cmrc_example::rc
+
+    LICENSE.txt
+)
+
+# Add more resource files to the library
+cmrc_add_resources(myrclib README.txt)
+
+# Add the resource library using the library ALIAS
+target_link_libraries(cmrc_example PRIVATE cmrc_example::rc)
+
+# ... or using the library name if preferred
+#target_link_libraries(cmrc_example PRIVATE myrclib)

--- a/example/LICENSE.txt
+++ b/example/LICENSE.txt
@@ -1,0 +1,16 @@
+MIT No Attribution
+
+Copyright 2023 technoyes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/example/README.txt
+++ b/example/README.txt
@@ -1,0 +1,1 @@
+The files in this directory are available under the MIT No Attribution License.

--- a/example/example.cpp
+++ b/example/example.cpp
@@ -1,0 +1,54 @@
+#include <cmrc/cmrc.hpp>
+#include <iostream>
+
+// Declare the resource library. Use the NAMESPACE specified in CMakeFile.txt.
+CMRC_DECLARE(rc);
+
+// Small helper to make output tidy
+void header(const char *s) {
+    std::cout << "\n\n---===[ " << s << " ]===---\n\n";
+}
+
+int main() {
+    // Get the filesystem object from the specified namespace (under cmrc::)
+    auto fs = cmrc::rc::get_filesystem();
+
+    // Access the text file resource in all possible ways and display the contents each time
+
+    header("open() returning iterable cmrc::file object");
+    auto license_file = fs.open("LICENSE.txt");
+    for(auto i = license_file.begin(); i != license_file.end(); ++i) {
+        std::cout << *i;
+    }
+    std::cout << "\n";
+
+    header("String (std::string), will return a copy of the data");
+    auto license_string= fs.get_as_string("LICENSE.txt");
+    std::cout << license_string << "\n";
+
+    header("String view (std::string_view), read-only view, avoids a copy of the data");
+    auto license_string_view = fs.get_as_string_view("LICENSE.txt");
+    std::cout << license_string_view << "\n";
+
+    header("String view (std::string_view) again, accessed using a raw pointer");
+    auto license_string_view2 = fs.get_as_string_view("LICENSE.txt");
+    auto license_string_view2_data = license_string_view2.data(); // const char*
+    auto license_string_view2_size = license_string_view2.size(); // std::size_t
+    std::cout << std::string(license_string_view2_data, license_string_view2_size) << "\n";
+
+    header("Raw pointer (const char*), relying on CMRC implicit trailing NULL byte");
+    auto license_raw_ptr = fs.get_as_raw_ptr("LICENSE.txt");
+    std::cout << std::string(license_raw_ptr) << "\n"; // Trailing NULL byte needed!
+
+    header("Raw pointer (const char*) with size return argument");
+    std::size_t license_raw_ptr2_size;
+    auto license_raw_ptr2 = fs.get_as_raw_ptr("LICENSE.txt", license_raw_ptr2_size);
+    std::cout << std::string(license_raw_ptr2, license_raw_ptr2_size) << "\n";
+
+    header("Raw pointer (const char*) and size (std::size_t)");
+    auto license_raw_ptr3 = fs.get_as_raw_ptr("LICENSE.txt");
+    auto license_raw_ptr3_size = fs.get_size("LICENSE.txt");
+    std::cout << std::string(license_raw_ptr3, license_raw_ptr3_size) << "\n";
+
+    return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,6 +101,17 @@ cmrc_add_test(
     )
 
 cmrc_add_test(
+    NAME fileaccess
+    RESOURCES flower.jpg
+    TEST_ARGV "${CMAKE_CURRENT_SOURCE_DIR}/flower.jpg"
+    )
+target_compile_features(fileaccess PRIVATE cxx_std_17)
+if(MSVC)
+    # MSVC favors their own backwards compatibilty over standards compliance
+    target_compile_options(fileaccess PRIVATE "/Zc:__cplusplus")
+endif()
+
+cmrc_add_test(
     NAME enoent
     WILL_FAIL
     )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,32 @@ cmrc_add_test(
     )
 
 cmrc_add_test(
+    NAME simple_string
+    PASS_REGEX "^Hello, world!"
+    RESOURCES
+        hello.txt
+    )
+
+cmrc_add_test(
+    NAME simple_string_view
+    PASS_REGEX "^Hello, world!"
+    RESOURCES
+        hello.txt
+    )
+target_compile_features(simple_string_view PRIVATE cxx_std_17)
+if(MSVC)
+    # MSVC favors their own backwards compatibilty over standards compliance
+    target_compile_options(simple_string_view PRIVATE "/Zc:__cplusplus")
+endif()
+
+cmrc_add_test(
+    NAME simple_raw_ptr
+    PASS_REGEX "^Hello, world!"
+    RESOURCES
+        hello.txt
+    )
+
+cmrc_add_test(
     NAME flower
     RESOURCES flower.jpg
     TEST_ARGV "${CMAKE_CURRENT_SOURCE_DIR}/flower.jpg"

--- a/tests/fileaccess.cpp
+++ b/tests/fileaccess.cpp
@@ -1,0 +1,101 @@
+#include <cmrc/cmrc.hpp>
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+
+CMRC_DECLARE(fileaccess);
+
+int main(int argc, char** argv) {
+    // Determine size of file on actual disk
+    if (argc != 2) {
+        std::cerr << "Invalid arguments passed to fileaccess\n";
+        return 2;
+    }
+    std::cout << "Reading flower from " << argv[1] << '\n';
+    std::ifstream flower_fs{argv[1], std::ios_base::binary};
+    if (!flower_fs) {
+        std::cerr << "Invalid filename passed to fileaccess: " << argv[1] << '\n';
+        return 2;
+    }
+    using iter         = std::istreambuf_iterator<char>;
+    const auto fs_size = std::distance(iter(flower_fs), iter());
+    flower_fs.seekg(0);
+    std::vector<char> flower_fs_vector((iter(flower_fs)), iter());
+    flower_fs.seekg(0);
+
+    // Get handle to resource filesystem
+    auto fs = cmrc::fileaccess::get_filesystem();
+
+    // Test access using open()
+    auto flower_open = fs.open("flower.jpg");
+    const auto open_size = std::distance(flower_open.begin(), flower_open.end());
+    if (fs_size != open_size) {
+        std::cerr << "open(): Sizes do not match: FS == " << fs_size << ", RC == " << open_size
+                  << "\n";
+        return 1;
+    }
+    if (!std::equal(flower_open.begin(), flower_open.end(), iter(flower_fs))) {
+        std::cerr << "open(): Contents do not match\n";
+        return 1;
+    }
+    flower_fs.seekg(0);
+
+    // Test access using get_as_string()
+    auto flower_string = fs.get_as_string("flower.jpg");
+    auto flower_string_size = flower_string.size();
+    if(fs_size != flower_string_size) {
+        std::cerr << "get_as_string(): Sizes do not match: FS == " << fs_size << ", RC == "
+                  << flower_string_size << "\n";
+        return 1;
+    }
+    if(0 != memcmp(flower_fs_vector.data(), flower_string.data(), flower_string_size)) {
+        std::cerr << "get_as_string(): Contents do not match\n";
+        return 1;
+    }
+
+#if __cplusplus >= 201703L
+    // Test access using get_as_string_view()
+    auto flower_string_view = fs.get_as_string_view("flower.jpg");
+    auto flower_string_view_size = flower_string_view.size();
+    if(fs_size != flower_string_view_size) {
+        std::cerr << "get_as_string_view(): Sizes do not match: FS == " << fs_size << ", RC == "
+                  << flower_string_view_size << "\n";
+        return 1;
+    }
+    if(0 != memcmp(flower_fs_vector.data(), flower_string_view.data(), flower_string_view_size)) {
+        std::cerr << "get_as_string_view(): Contents do not match\n";
+        return 1;
+    }
+#endif
+
+    // Test access using get_as_raw_ptr() + get_size()
+    auto flower_raw_ptr = fs.get_as_raw_ptr("flower.jpg");
+    auto flower_raw_ptr_size = fs.get_size("flower.jpg");
+    if(fs_size != flower_raw_ptr_size) {
+        std::cerr << "get_as_raw_ptr()+get_size(): Sizes do not match: FS == " << fs_size << ", RC == "
+                  << flower_raw_ptr_size << "\n";
+        return 1;
+    }
+    if(0 != memcmp(flower_fs_vector.data(), flower_raw_ptr, flower_raw_ptr_size)) {
+        std::cerr << "get_as_raw_ptr()+get_size(): Contents do not match\n";
+        return 1;
+    }
+
+    // Test access using get_as_raw_ptr()
+    std::size_t flower_raw_ptr_size2{0};
+    auto flower_raw_ptr2 = fs.get_as_raw_ptr("flower.jpg", flower_raw_ptr_size2);
+    if(fs_size != flower_raw_ptr_size2) {
+        std::cerr << "get_as_raw_ptr(): Sizes do not match: FS == " << fs_size << ", RC == "
+                  << flower_raw_ptr_size2 << "\n";
+        return 1;
+    }
+    if(0 != memcmp(flower_fs_vector.data(), flower_raw_ptr2, flower_raw_ptr_size2)) {
+        std::cerr << "get_as_raw_ptr(): Contents do not match\n";
+        return 1;
+    }
+
+    // Explictly return success
+    return 0;
+}

--- a/tests/flower.cpp
+++ b/tests/flower.cpp
@@ -35,4 +35,5 @@ int main(int argc, char** argv) {
         std::cerr << "Flower file contents do not match\n";
         return 1;
     }
+    return 0;
 }

--- a/tests/simple_raw_ptr.cpp
+++ b/tests/simple_raw_ptr.cpp
@@ -1,0 +1,13 @@
+#include <cmrc/cmrc.hpp>
+
+#include <iostream>
+
+CMRC_DECLARE(simple_raw_ptr);
+
+int main() {
+    auto fs = cmrc::simple_raw_ptr::get_filesystem();
+    const char* data = fs.get_as_raw_ptr("hello.txt");
+    // This kind of use relies on the implicit NULL byte added by
+    // CMRC as well as that the file has no NULL bytes inside it.
+    std::cout << std::string(data) << '\n';
+}

--- a/tests/simple_string.cpp
+++ b/tests/simple_string.cpp
@@ -1,0 +1,11 @@
+#include <cmrc/cmrc.hpp>
+
+#include <iostream>
+
+CMRC_DECLARE(simple_string);
+
+int main() {
+    auto fs = cmrc::simple_string::get_filesystem();
+    std::string a_string = fs.get_as_string("hello.txt");
+    std::cout << a_string << '\n';
+}

--- a/tests/simple_string_view.cpp
+++ b/tests/simple_string_view.cpp
@@ -1,0 +1,11 @@
+#include <cmrc/cmrc.hpp>
+
+#include <iostream>
+
+CMRC_DECLARE(simple_string_view);
+
+int main() {
+    auto fs = cmrc::simple_string_view::get_filesystem();
+    std::string_view a_string_view = fs.get_as_string_view("hello.txt");
+    std::cout << a_string_view << '\n';
+}


### PR DESCRIPTION
This change adds support for directly fetching resource data as std::string as well as raw "const char*" combined with std::size_t. This allows cleaner code in use cases where the existing file interface is overkill.

Complete with docs and tests. Also added small doc about the NULL byte that is appended to all resources.

Not super happy about the get_as_raw_ptr() returning size through an output argument, but I can't think of a cleaner way.

Thoughts?